### PR TITLE
Fix calling Stored Procedure with kwargs

### DIFF
--- a/postgresql/driver/pq3.py
+++ b/postgresql/driver/pq3.py
@@ -1856,14 +1856,15 @@ class StoredProcedure(pg_api.StoredProcedure):
 						self.name, k.message
 					)
 				)
+			argc = len(self._input_attmap)
 			word_idx.sort(key = get1)
 			current_word = word_idx.pop(0)
 			for x in range(argc):
-				if x == current_word[1]:
+				if current_word != None and x == current_word[1]:
 					input.append(current_word[0])
-					current_word = word_idx.pop(0)
+					current_word = word_idx.pop(0) if len(word_idx) != 0 else None
 				else:
-					input.append(argiter.next())
+					input.append(next(argiter))
 		else:
 			input = args
 


### PR DESCRIPTION
Fixes issue with calling a StoredProcedure with kwargs. The for loop depended on the variable 'argc' which was not declared. This declares the variable, and updates the handling of current_word in the loop to handle instances where the number of items in kw is less than the number of arguments the stored procedure requires.
