### PR TITLE
enable older ipaddr module, for compatibility with older versions of python

### DIFF
--- a/postgresql/test/test_driver.py
+++ b/postgresql/test/test_driver.py
@@ -287,7 +287,10 @@ type_samples = [
 ]
 
 try:
-	import ipaddress
+	try:
+		import ipaddress
+	except ImportError:
+		import ipaddr as ipaddress
 
 	type_samples.extend([
 		('inet', [

--- a/postgresql/types/io/pg_network.py
+++ b/postgresql/types/io/pg_network.py
@@ -1,28 +1,52 @@
 from .. import INETOID, CIDROID, MACADDROID
 from . import lib
-import ipaddress
+try:
+	import ipaddress
+	oid_to_type = {
+		MACADDROID : str,
+		INETOID: ipaddress._IPAddressBase,
+		CIDROID: ipaddress._BaseNetwork,
+		}
+	def inet_pack(ob, pack = lib.net_pack, Constructor = ipaddress.ip_address):
+		a = Constructor(ob)
+		return pack((a.version, None, a.packed))
 
-oid_to_type = {
-	MACADDROID : str,
-	INETOID: ipaddress._IPAddressBase,
-	CIDROID: ipaddress._BaseNetwork,
-}
+	def cidr_pack(ob, pack = lib.net_pack, Constructor = ipaddress.ip_network):
+		a = Constructor(ob)
+		return pack((a.version, a.prefixlen, a.network_address.packed))
 
-def inet_pack(ob, pack = lib.net_pack, Constructor = ipaddress.ip_address):
-	a = Constructor(ob)
-	return pack((a.version, None, a.packed))
+	def inet_unpack(data, unpack = lib.net_unpack, Constructor = ipaddress.ip_address):
+		version, mask, data = unpack(data)
+		return Constructor(data)
 
-def cidr_pack(ob, pack = lib.net_pack, Constructor = ipaddress.ip_network):
-	a = Constructor(ob)
-	return pack((a.version, a.prefixlen, a.network_address.packed))
+	def cidr_unpack(data, unpack = lib.net_unpack, Constructor = ipaddress.ip_network):
+		version, mask, data = unpack(data)
+		return Constructor(data).supernet(new_prefix=mask)
 
-def inet_unpack(data, unpack = lib.net_unpack, Constructor = ipaddress.ip_address):
-	version, mask, data = unpack(data)
-	return Constructor(data)
+except ImportError:
+	import ipaddr as ipaddress
+	oid_to_type = {
+		MACADDROID : str,
+		INETOID: ipaddress._IPAddrBase,
+		CIDROID: ipaddress._BaseNet,
+		}
+	def inet_pack(ob, pack = lib.net_pack, Constructor = ipaddress.IPAddress):
+		a = Constructor(ob)
+		return pack((a.version, None, a.packed))
 
-def cidr_unpack(data, unpack = lib.net_unpack, Constructor = ipaddress.ip_network):
-	version, mask, data = unpack(data)
-	return Constructor(data).supernet(new_prefix=mask)
+	def cidr_pack(ob, pack = lib.net_pack, Constructor = ipaddress.IPNetwork):
+		a = Constructor(ob)
+		return pack((a.version, a.prefixlen, a.network.packed))
+
+	def inet_unpack(data, unpack = lib.net_unpack, Constructor = ipaddress.IPAddress):
+		version, mask, data = unpack(data)
+		return Constructor(data)
+
+	def cidr_unpack(data, unpack = lib.net_unpack, Constructor = ipaddress.IPNetwork):
+		version, mask, data = unpack(data)
+		return Constructor(data).supernet(new_prefix=mask)
+
+
 
 oid_to_io = {
 	MACADDROID : (lib.macaddr_pack, lib.macaddr_unpack, str),


### PR DESCRIPTION
Python only added the ipaddress module to its standard library in
3.3, but some older systems will still be using older versions of
python3 for some time. (e.g. debian wheezy, which will probably be
supported into 2016, has python 3.1).

For these older systems, the simplest route is to install the ipaddr
module, which has slightly different naming schemes for some
functions.

For systems already running python 3.3, this patch won't change their
behavior, but it will make it possible to run py-postgresql against
python 3.1, as long as the external ipaddr module is also installed
separately.
