### PR TITLE
Use setuptools in favour of distutils.core

### DIFF
--- a/postgresql/release/distutils.py
+++ b/postgresql/release/distutils.py
@@ -13,7 +13,10 @@ use `default_prefix` which is derived from the module's `__package__`.
 import sys
 import os
 from ..project import version, name, identity as url
-from distutils.core import Extension, Command
+try:
+	from setuptools import Extension, Command
+except ImportError as e:
+	from distutils.core import Extension, Command
 
 LONG_DESCRIPTION = """
 py-postgresql is a set of Python modules providing interfaces to various parts

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,8 @@ defaults = dist.standard_setup_keywords()
 sys.dont_write_bytecode = False
 
 if __name__ == '__main__':
-	from distutils.core import setup
+	try:
+		from setuptools import setup
+	except ImportError as e:
+		from distutils.core import setup
 	setup(**defaults)


### PR DESCRIPTION
It will use setuptools if available and fallback to distutils.core on ImportError.
It's helps when you would like to build a wheel for it.