### PR TITLE
Fx the version parsing to support Debian

### DIFF
--- a/postgresql/versionstring.py
+++ b/postgresql/versionstring.py
@@ -15,7 +15,7 @@ def split(vstr : str) -> (
 	Split a PostgreSQL version string into a tuple
 	(major,minor,patch,...,state_class,state_level)
 	"""
-	v = vstr.strip().split('.')
+	v = vstr.strip().split(' ')[0].split('.')
 
 	# Get rid of the numbers around the state_class (beta,a,dev,alpha, etc)
 	state_class = v[-1].strip('0123456789')


### PR DESCRIPTION
The bug already reported and the fix proposed by Marten KARL on Debian bug tracking system (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=890646)

The fix aims to support the customized version string for some Debian postgresql packages. So, the version string `10.3 (Debian 10.3-1.pgdg90+1)` will be split by the space to consider only the first part.

The following error raised when I used Debian's postgresql package. This because the customized version string in  Debian makes the `patch` value having an invalid string rather than an integer.
```
  File "/lib/python3.6/site-packages/postgresql/driver/dbapi20.py", line 409, in connect
    return driver.connect(**params)
  File "/lib/python3.6/site-packages/postgresql/driver/pq3.py", line 3037, in connect
    c.connect()
  File "/lib/python3.6/site-packages/postgresql/driver/dbapi20.py", line 354, in connect
    super().connect(*args, **kw)
  File "/lib/python3.6/site-packages/postgresql/driver/pq3.py", line 2427, in connect
    self._establish()
  File "/lib/python3.6/site-packages/postgresql/driver/pq3.py", line 2559, in _establish
    self.version_info = pg_version.normalize(pg_version.split(sv))
  File "/lib/python3.6/site-packages/postgresql/versionstring.py", line 28, in split
    vlist = [int(x or '0') for x in v[:-1]]
  File "/lib/python3.6/site-packages/postgresql/versionstring.py", line 28, in <listcomp>
    vlist = [int(x or '0') for x in v[:-1]]
ValueError: invalid literal for int() with base 10: '3 (Debian 10'
```

By excluding the extra part form the version string, the package works fine.