### PR TITLE
Resolve Heroku PostgreSQL connection

### DIFF
--- a/postgresql/versionstring.py
+++ b/postgresql/versionstring.py
@@ -15,7 +15,7 @@ def split(vstr : str) -> (
 	Split a PostgreSQL version string into a tuple
 	(major,minor,patch,...,state_class,state_level)
 	"""
-	v = vstr.strip().split('.')
+	v = vstr.strip().split(' ')[0].split('.')
 
 	# Get rid of the numbers around the state_class (beta,a,dev,alpha, etc)
 	state_class = v[-1].strip('0123456789')

--- a/postgresql/versionstring.py
+++ b/postgresql/versionstring.py
@@ -15,6 +15,10 @@ def split(vstr : str) -> (
 	Split a PostgreSQL version string into a tuple
 	(major,minor,patch,...,state_class,state_level)
 	"""
+	# Verify if the version is a complete string
+	if re.match('PostgreSQL', vstr):
+		vstr = vstr.strip().strip('PostgreSQL')
+	
 	v = vstr.strip().split(' ')[0].split('.')
 
 	# Get rid of the numbers around the state_class (beta,a,dev,alpha, etc)


### PR DESCRIPTION
Resolve the error "ValueError: invalid literal for int() with base 10: '6 (Ubuntu 10'" when try to connect with Heroku PostgreSQL