### PR TITLE
HACK: update versionstring to parse OS info from PG_VERSION

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 build
 dist
 *.pyc
+
+# JetBrains
+.idea

--- a/postgresql/versionstring.py
+++ b/postgresql/versionstring.py
@@ -8,12 +8,13 @@ PostgreSQL version string parsing.
 (8, 0, 1, None, None)
 """
 
+
 def split(vstr: str) -> tuple:
 	"""
 	Split a PostgreSQL version string into a tuple.
 	(major, minor, patch, ..., state_class, state_level)
 	"""
-	v = vstr.strip().split('.')
+	v = vstr.strip().split('(')
 
 	# Get rid of the numbers around the state_class (beta,a,dev,alpha, etc)
 	state_class = v[-1].strip('0123456789')
@@ -23,7 +24,7 @@ def split(vstr: str) -> tuple:
 			state_level = None
 		else:
 			state_level = int(state_level)
-		vlist = [int(x or '0') for x in v[:-1]]
+		vlist = [int(float(x) or '0') for x in v[:-1]]
 		if last_version:
 			vlist.append(int(last_version))
 		vlist += [None] * (3 - len(vlist))


### PR DESCRIPTION
## Why

This is a hack to parse out OS level info that pollutes PG_VERSION and causes versionstring.split throw a invalid literal of base 10. Basically using the Postgres docker image, the PG_VERSION has OS info init and throws off the parsing. 

## How
- Hack in some additional parsing to get the barebones PG_VERSION.

### TODO 
- This is only a hack until a proper fix can be introduced by the maintainers. See thread https://github.com/python-postgres/fe/issues/109