### PR TITLE
Python 3.10: Update another collections.abc import

### DIFF
--- a/postgresql/copyman.py
+++ b/postgresql/copyman.py
@@ -9,7 +9,7 @@ function for a high-level interface to using the `CopyManager`.
 """
 import sys
 from abc import abstractmethod, abstractproperty
-from collections import Iterator
+from collections.abc import Iterator
 from .python.element import Element, ElementSet
 from .python.structlib import ulong_unpack, ulong_pack
 from .protocol.buffer import pq_message_stream

--- a/postgresql/documentation/notifyman.rst
+++ b/postgresql/documentation/notifyman.rst
@@ -20,7 +20,7 @@ receives notifications.
 
 The `postgresql.notifyman.NotificationManager` class is used to wait for
 messages to come in on a set of connections, pick up the messages, and deliver
-the messages to the object's user via the `collections.Iterator` protocol.
+the messages to the object's user via the `collections.abc.Iterator` protocol.
 
 
 Listening on a Single Connection


### PR DESCRIPTION
Most of the work was done in 72841f1c9eb81b4017f9a0bd0545ba94edeb8a6f, but one import got missed.

This is enough to pass the test suite on Python 3.10.