### PR TITLE
Fix version split for packages using --with-extra-version option

### DIFF
--- a/postgresql/installation.py
+++ b/postgresql/installation.py
@@ -209,7 +209,7 @@ class Installation(pg_api.Installation):
 		"""
 		self.info = info
 		self.version = self.info["version"]
-		self.type, vs = self.version.split()
+		self.type, vs = self.version.split()[:2]
 		self.version_info = versionstring.normalize(versionstring.split(vs))
 		self.configure_options = dict(
 			parse_configure_options(self.info.get('configure', ''))


### PR DESCRIPTION
This patch solves the error below when we have some extra data in the version string retrieved from `pg_config` output (like in `PostgreSQL 12.9 (Ubuntu 12.9-0ubuntu0.20.04.1)`):
```
...
File "...postgresql/installation.py", line 212, in __init__
    self.type, vs = self.version.split()
ValueError: too many values to unpack (expected 2)
```

As the extra data in the version string is added with the `--with-extra-version` option in the PostgreSQL `configure` script, like in the example command below, we can rely in getting just the two first parts of the version string without introducing a weird behavior for the already working version strings.
```sh
./configure --with-extra-version=" (Ubuntu 12.9-0ubuntu0.20.04.1)"
```