### PR TITLE
ubuntu/debian compatibility

### DIFF
--- a/postgresql/versionstring.py
+++ b/postgresql/versionstring.py
@@ -13,7 +13,7 @@ def split(vstr: str) -> tuple:
 	Split a PostgreSQL version string into a tuple.
 	(major, minor, patch, ..., state_class, state_level)
 	"""
-	v = vstr.strip().split('.')
+	v = vstr.strip().split(' ')[0].split('.')
 
 	# Get rid of the numbers around the state_class (beta,a,dev,alpha, etc)
 	state_class = v[-1].strip('0123456789')


### PR DESCRIPTION
server_version at ubuntu looks like "12.10 (Ubuntu 12.10-1.pgdg20.04+1)"
and split('.') produce an error "ValueError: invalid literal for int() with base 10: '10 (Ubuntu 12'"
solution was found here https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=890646 for Debian 9.3