### PR TITLE
Fix build with newer compilers on FreeBSD

### DIFF
--- a/postgresql/port/_optimized/buffer.c
+++ b/postgresql/port/_optimized/buffer.c
@@ -587,7 +587,7 @@ PyTypeObject pq_message_stream_Type = {
 	sizeof(struct p_buffer),		/* tp_basicsize */
 	0,										/* tp_itemsize */
 	p_dealloc,							/* tp_dealloc */
-	NULL,									/* tp_print */
+	0,									/* tp_print */
 	NULL,									/* tp_getattr */
 	NULL,									/* tp_setattr */
 	NULL,									/* tp_compare */

--- a/postgresql/port/_optimized/wirestate.c
+++ b/postgresql/port/_optimized/wirestate.c
@@ -248,7 +248,7 @@ PyTypeObject WireState_Type = {
 	sizeof(struct wirestate),				/* tp_basicsize */
 	0,												/* tp_itemsize */
 	ws_dealloc,									/* tp_dealloc */
-	NULL,											/* tp_print */
+	0,											/* tp_print */
 	NULL,											/* tp_getattr */
 	NULL,											/* tp_setattr */
 	NULL,											/* tp_compare */


### PR DESCRIPTION
**On FreeBSD current** the installation process of [databases/py-postgresql](https://www.freshports.org/databases/py-postgresql) is broken [1]. `optimized.cpython-39.so` is not built most likely because due to compiler errors:
    
```
    In file included from postgresql/port/_optimized/module.c:43:
    postgresql/port/_optimized/buffer.c:590:2: error: incompatible pointer to integer conversion initializing 'Py_ssize_t' (aka 'long') with an expression of type 'void *' [-Wint-conversion]
            NULL,                                                                   /* tp_print */
            ^~~~
    /usr/include/sys/_null.h:34:14: note: expanded from macro 'NULL'
                    ^~~~~~~~~~~
```    

The same happens with `postgresql/port/_optimized/wirestate.c:251:2` and is reported on FreeBSD's Bugzilla [2].
    
The patch tries to solve the problem by setting the value of NULL to 0 for the argument tp_print. This seems to work as expected, hopefully without regressions.

[1] [https://portsfallout.com/fallout?port=databases%2Fpy-postgresql&maintainer=&env=main-amd64-default&category=&flavor=](https://portsfallout.com/fallout?port=databases%2Fpy-postgresql&maintainer=&env=main-amd64-default&category=&flavor=)
[2] [https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271165](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271165)
