### PR TITLE
Add driver option to disable TLS certificate verification

### DIFF
--- a/postgresql/documentation/driver.rst
+++ b/postgresql/documentation/driver.rst
@@ -282,6 +282,8 @@ interfaces:
  ``sslrootcrlfile``
   Revocation list file path. [Currently not checked.]
 
+ ``sslnoverify``
+  Optionally disable certificate verification.
 
 Connections
 ===========

--- a/postgresql/driver/pq3.py
+++ b/postgresql/driver/pq3.py
@@ -2796,11 +2796,13 @@ class Connector(pg_api.Connector):
 		self.sslcrtfile = parameters.get('sslcrtfile') or None
 		self.sslrootcrtfile = parameters.get('sslrootcrtfile') or None
 		self.sslrootcrlfile = parameters.get('sslrootcrlfile') or None
+		self.sslnoverify = parameters.get('sslnoverify') or None
 
 		self._socket_secure = {
 			'keyfile': self.sslkeyfile,
 			'certfile': self.sslcrtfile,
 			'ca_certs': self.sslrootcrtfile,
+			'noverify': self.sslnoverify,
 		}
 
 		if self.sslrootcrlfile is not None:

--- a/postgresql/python/socket.py
+++ b/postgresql/python/socket.py
@@ -51,9 +51,12 @@ class SocketFactory(object):
 	@property
 	def _security_context(self):
 		if self._security_context_ii is None:
-			from ssl import SSLContext, PROTOCOL_TLS_CLIENT
+			from ssl import SSLContext, PROTOCOL_TLS_CLIENT, CERT_NONE
 			ctx = self._security_context_ii = SSLContext(PROTOCOL_TLS_CLIENT)
 			ctx.check_hostname = False
+
+			if self.socket_secure.get('noverify') is not None:
+				ctx.verify_mode = CERT_NONE
 
 			cf = self.socket_secure.get('certfile')
 			kf = self.socket_secure.get('keyfile')
@@ -63,6 +66,8 @@ class SocketFactory(object):
 			ca = self.socket_secure.get('ca_certs')
 			if ca is not None:
 				self._security_context_ii.load_verify_locations(ca)
+			else:
+				self._security_context_ii.load_default_certs()
 
 		return self._security_context_ii
 


### PR DESCRIPTION
Add driver option to disable TLS certificate verification, which can be useful during testing.
Not recommended for production use, of course.